### PR TITLE
Make Big parser more permissive

### DIFF
--- a/big.js
+++ b/big.js
@@ -55,7 +55,7 @@
     /***********************************************************************************/
 
         P = Big.prototype,
-        isValid = /^-?\d+(?:\.\d+)?(?:e[+-]?\d+)?$/i,
+        isValid = /^-?\d*(?:\.\d*)?(?:e[+-]?\d*)?$/i,
         ONE = new Big(1);
 
 
@@ -89,7 +89,7 @@
         if ( n === 0 && 1 / n < 0 ) {
             n = '-0'
         // Ensure 'n' is string and check validity.
-        } else if ( !isValid.test(n += '') ) {
+        } else if ( !isValid.test(n += '') || n === '' || n[0] === 'e') {
             throw NaN
         }
 

--- a/test/cmp.js
+++ b/test/cmp.js
@@ -4055,10 +4055,7 @@ var count = (function cmp(Big) {
     assertException(function () {new Big('12.345').cmp('- 99')}, ".cmp('- 99')");
     assertException(function () {new Big('12.345').cmp('9.9.9')}, ".cmp('9.9.9')");
     assertException(function () {new Big('12.345').cmp('10.1.0')}, ".cmp('10.1.0')");
-    assertException(function () {new Big('12.345').cmp('234.')}, ".cmp('234.')");
-    assertException(function () {new Big('12.345').cmp('.5')}, ".cmp('.5')");
     assertException(function () {new Big('12.345').cmp('0x16')}, ".cmp('0x16')");
-    assertException(function () {new Big('12.345').cmp('1e')}, ".cmp('1e')");
     assertException(function () {new Big('12.345').cmp('8 e')}, ".cmp('8 e')");
     assertException(function () {new Big('12.345').cmp('77-e')}, ".cmp('77-e')");
     assertException(function () {new Big('12.345').cmp('123e.0')}, ".cmp('123e.0')");

--- a/test/div.js
+++ b/test/div.js
@@ -9928,10 +9928,7 @@ var count = (function div(Big) {
     assertException(function () {new Big('12.345').div('- 99')}, ".div('- 99')");
     assertException(function () {new Big('12.345').div('9.9.9')}, ".div('9.9.9')");
     assertException(function () {new Big('12.345').div('10.1.0')}, ".div('10.1.0')");
-    assertException(function () {new Big('12.345').div('234.')}, ".div('234.')");
-    assertException(function () {new Big('12.345').div('.5')}, ".div('.5')");
     assertException(function () {new Big('12.345').div('0x16')}, ".div('0x16')");
-    assertException(function () {new Big('12.345').div('1e')}, ".div('1e')");
     assertException(function () {new Big('12.345').div('8 e')}, ".div('8 e')");
     assertException(function () {new Big('12.345').div('77-e')}, ".div('77-e')");
     assertException(function () {new Big('12.345').div('123e.0')}, ".div('123e.0')");

--- a/test/minus.js
+++ b/test/minus.js
@@ -1775,10 +1775,7 @@ var count = (function minus(Big) {
     assertException(function () {new Big('12.345').minus('- 99')}, ".minus('- 99')");
     assertException(function () {new Big('12.345').minus('9.9.9')}, ".minus('9.9.9')");
     assertException(function () {new Big('12.345').minus('10.1.0')}, ".minus('10.1.0')");
-    assertException(function () {new Big('12.345').minus('234.')}, ".minus('234.')");
-    assertException(function () {new Big('12.345').minus('.5')}, ".minus('.5')");
     assertException(function () {new Big('12.345').minus('0x16')}, ".minus('0x16')");
-    assertException(function () {new Big('12.345').minus('1e')}, ".minus('1e')");
     assertException(function () {new Big('12.345').minus('8 e')}, ".minus('8 e')");
     assertException(function () {new Big('12.345').minus('77-e')}, ".minus('77-e')");
     assertException(function () {new Big('12.345').minus('123e.0')}, ".minus('123e.0')");

--- a/test/mod.js
+++ b/test/mod.js
@@ -1823,10 +1823,7 @@ var count = (function mod(Big) {
     assertException(function () {new Big('12.345').mod('- 99')}, ".mod('- 99')");
     assertException(function () {new Big('12.345').mod('9.9.9')}, ".mod('9.9.9')");
     assertException(function () {new Big('12.345').mod('10.1.0')}, ".mod('10.1.0')");
-    assertException(function () {new Big('12.345').mod('234.')}, ".mod('234.')");
-    assertException(function () {new Big('12.345').mod('.5')}, ".mod('.5')");
     assertException(function () {new Big('12.345').mod('0x16')}, ".mod('0x16')");
-    assertException(function () {new Big('12.345').mod('1e')}, ".mod('1e')");
     assertException(function () {new Big('12.345').mod('8 e')}, ".mod('8 e')");
     assertException(function () {new Big('12.345').mod('77-e')}, ".mod('77-e')");
     assertException(function () {new Big('12.345').mod('123e.0')}, ".mod('123e.0')");

--- a/test/plus.js
+++ b/test/plus.js
@@ -1898,10 +1898,7 @@ var count = (function plus(Big) {
     assertException(function () {new Big('12.345').plus('- 99')}, ".plus('- 99')");
     assertException(function () {new Big('12.345').plus('9.9.9')}, ".plus('9.9.9')");
     assertException(function () {new Big('12.345').plus('10.1.0')}, ".plus('10.1.0')");
-    assertException(function () {new Big('12.345').plus('234.')}, ".plus('234.')");
-    assertException(function () {new Big('12.345').plus('.5')}, ".plus('.5')");
     assertException(function () {new Big('12.345').plus('0x16')}, ".plus('0x16')");
-    assertException(function () {new Big('12.345').plus('1e')}, ".plus('1e')");
     assertException(function () {new Big('12.345').plus('8 e')}, ".plus('8 e')");
     assertException(function () {new Big('12.345').plus('77-e')}, ".plus('77-e')");
     assertException(function () {new Big('12.345').plus('123e.0')}, ".plus('123e.0')");

--- a/test/times.js
+++ b/test/times.js
@@ -2144,10 +2144,7 @@ var count = (function times(Big) {
     assertException(function () {new Big('1').times('- 99')}, ".times('- 99')");
     assertException(function () {new Big('1').times('9.9.9')}, ".times('9.9.9')");
     assertException(function () {new Big('1').times('10.1.0')}, ".times('10.1.0')");
-    assertException(function () {new Big('1').times('234.')}, ".times('234.')");
-    assertException(function () {new Big('1').times('.5')}, ".times('.5')");
     assertException(function () {new Big('1').times('0x16')}, ".times('0x16')");
-    assertException(function () {new Big('1').times('1e')}, ".times('1e')");
     assertException(function () {new Big('1').times('8 e')}, ".times('8 e')");
     assertException(function () {new Big('1').times('77-e')}, ".times('77-e')");
     assertException(function () {new Big('1').times('123e.0')}, ".times('123e.0')");

--- a/test/toString.js
+++ b/test/toString.js
@@ -1025,6 +1025,18 @@ var count = (function toString(Big) {
     T('-0.00126806436344', '-0.001268064363440000000000000');
     T('162145242000', '00162145242000.0');
 
+    T('234', '234.');
+    T('0.5', '.5');
+    T('-0.1', '-.1');
+    T('-2', '-2.');
+    T('5', '5e');
+    T('10', '1.e1');
+    T('-5', '-5e');
+    T('1', '1e-');
+    T('0.1', '.1e');
+    T('-0.1', '-.1e');
+    T('40', '4.E1');
+
     assertException(function () {new Big(undefined)}, "new Big(undefined)");
     assertException(function () {new Big(null)}, "new Big(null)");
     assertException(function () {new Big(NaN)}, "new Big(NaN)");
@@ -1046,15 +1058,11 @@ var count = (function toString(Big) {
     assertException(function () {new Big('- 99')}, "new Big('- 99')");
     assertException(function () {new Big('9.9.9')}, "new Big('9.9.9')");
     assertException(function () {new Big('10.1.0')}, "new Big('10.1.0')");
-    assertException(function () {new Big('234.')}, "new Big('234.')");
-    assertException(function () {new Big('.5')}, "new Big('.5')");
     assertException(function () {new Big('0x16')}, "new Big('0x16')");
-    assertException(function () {new Big('1e')}, "new Big('1e')");
     assertException(function () {new Big('8 e')}, "new Big('8 e')");
     assertException(function () {new Big('77-e')}, "new Big('77-e')");
     assertException(function () {new Big('123e.0')}, "new Big('123e.0')");
     assertException(function () {new Big('4e1.')}, "new Big('4e1.')");
-    assertException(function () {new Big('4.E1')}, "new Big('4.E1')");
     assertException(function () {new Big('41a')}, "new Big('41a')");
     assertException(function () {new Big('99ee')}, "new Big('99ee')");
     assertException(function () {new Big('e0')}, "new Big('e0')");


### PR DESCRIPTION
isValid regex used in Big constructor was requiring digits before and after the decimal and after the exponent. parseFloat handles the case of any of these being missing, so modify isValid to come closer to matching parseFloat.

parseFloat also allows much more whitespace, but leave that alone.
