### PR TITLE
add toFloat() to prototype

### DIFF
--- a/big.js
+++ b/big.js
@@ -1119,6 +1119,13 @@
         return format(this, sd - 1, 2);
     };
 
+    /*
+     * Return a primitive JavaScript number with the value of this Big.
+     */
+    P.toFloat = function () {
+        return parseFloat(this);
+    }
+
 
     // Export
 


### PR DESCRIPTION
Added the `toFloat()` prototype function for conveniently parsing a Big in a chained form.

Before:

    var result = parseFloat(Big(35).div(4));

After:

    var result = Big(35).div(4).toFloat();