### PR TITLE
Avoid out of bound deoptimization

### DIFF
--- a/big.js
+++ b/big.js
@@ -208,18 +208,20 @@
             e = n.length;
         }
 
+        nL = n.length;
+
         // Determine leading zeros.
-        for (i = 0; n.charAt(i) == '0'; i++) {
+        for (i = 0; i < nL && n.charAt(i) == '0'; i++) {
         }
 
-        if (i == (nL = n.length)) {
+        if (i == nL) {
 
             // Zero.
             x.c = [ x.e = 0 ];
         } else {
 
             // Determine trailing zeros.
-            for (; n.charAt(--nL) == '0';) {
+            for (; nL > 0 && n.charAt(--nL) == '0';) {
             }
 
             x.e = e - i - 1;


### PR DESCRIPTION
Hello!

We're using big.js in my current project and during performance investigation I've noticed that parse function is not optimized by v8:
```
$ node --trace-deopt perf/bigtime plus 10000 40

...
[deoptimizing (DEOPT eager): begin 0x56f390ee551 <JS Function parse (SharedFunctionInfo 0x29bdc58eaf01)> (opt #176) @26, FP to SP delta: 96, caller sp: 0x7ffe6414b770]
            ;;; deoptimize at </opt/sws/big.js/big.js:212:23>, out of bounds
  reading input frame parse => node=438, args=3, height=4; inputs:
      0: 0x56f390ee551 ; [fp - 16] 0x56f390ee551 <JS Function parse (SharedFunctionInfo 0x29bdc58eaf01)>
      1: 0x38684f02241 ; [fp + 32] 0x38684f02241 <undefined>
      2: 0xca5b39ee609 ; [fp + 24] 0xca5b39ee609 <a Big with map 0x453956506a1>
      3: 0xdca67660c89 ; rbx 0xdca67660c89 <String[1]: 0>
      4: 0x56f390cad01 ; [fp - 24] 0x56f390cad01 <FixedArray[18]>
      5: 1 ; rdx 
      6: 1 ; rax 
      7: 0x38684f02241 ; (literal 1) 0x38684f02241 <undefined>
  translating frame parse => node=438, height=24
    0x7ffe6414b768: [top + 72] <- 0x38684f02241 ;  0x38684f02241 <undefined>  (input #1)
    0x7ffe6414b760: [top + 64] <- 0xca5b39ee609 ;  0xca5b39ee609 <a Big with map 0x453956506a1>  (input #2)
    0x7ffe6414b758: [top + 56] <- 0xdca67660c89 ;  0xdca67660c89 <String[1]: 0>  (input #3)
    -------------------------
    0x7ffe6414b750: [top + 48] <- 0x7b375eab140 ;  caller's pc
    0x7ffe6414b748: [top + 40] <- 0x7ffe6414b788 ;  caller's fp
    0x7ffe6414b740: [top + 32] <- 0x56f390cad01 ;  context    0x56f390cad01 <FixedArray[18]>  (input #4)
    0x7ffe6414b738: [top + 24] <- 0x56f390ee551 ;  function    0x56f390ee551 <JS Function parse (SharedFunctionInfo 0x29bdc58eaf01)>  (input #0)
    -------------------------
    0x7ffe6414b730: [top + 16] <- 0x100000000 ;  1  (input #5)
    0x7ffe6414b728: [top + 8] <- 0x100000000 ;  1  (input #6)
    0x7ffe6414b720: [top + 0] <- 0x38684f02241 ;  0x38684f02241 <undefined>  (input #7)
[deoptimizing (eager): end 0x56f390ee551 <JS Function parse (SharedFunctionInfo 0x29bdc58eaf01)> @26 => node=438, pc=0x7b375ea645d, caller sp=0x7ffe6414b770, state=NO_REGISTERS, took 0.195 ms]
[removing optimized code for: parse]
```
It happens because of out of bound index access. 

With the fix on my machine perf test works ~25% faster. Tested on v8: v4.8.4, v6.9.5, v7.7.3, v8.2.1 .

Hope it helps :)