### PR TITLE
Add a named commonjs export for Big

### DIFF
--- a/big.js
+++ b/big.js
@@ -1136,6 +1136,7 @@
     // Node and other CommonJS-like environments that support module.exports.
     } else if (typeof module !== 'undefined' && module.exports) {
         module.exports = Big;
+        module.exports.Big = Big;
 
     //Browser.
     } else {


### PR DESCRIPTION
This enables the proper use of the module with es6 module syntax.

With just `module.exports = Big`, there is no proper way of importing it in a project using es6 module syntax. This is because the es6 import syntax doesn't allow direct access to the exports object.

This can be worked around when importing directly into a project that is transpiled into commonjs, but if you want to create a library that uses the es6 module syntax (to allow for tree shaking etc), those tricks are not usable anymore.

With the named export the old `var Big = require('big.js')` still works, but the es6 `import { Big } from 'big.js'` also works.