### PR TITLE
Made CommonJS the first branch of the export if statement

### DIFF
--- a/big.js
+++ b/big.js
@@ -1,9 +1,9 @@
-/* big.js v3.1.3 https://github.com/MikeMcl/big.js/LICENCE */
+/* big.js v3.2.0 https://github.com/MikeMcl/big.js/LICENCE */
 ;(function (global) {
     'use strict';
 
 /*
-  big.js v3.1.3
+  big.js v3.2.0
   A small, fast, easy-to-use library for arbitrary-precision decimal arithmetic.
   https://github.com/MikeMcl/big.js/
   Copyright (c) 2014 Michael Mclaughlin <M8ch88l@gmail.com>
@@ -1128,17 +1128,17 @@
 
     Big = bigFactory();
 
+    // Node and other CommonJS-like environments that support module.exports.
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = Big;
+        module.exports.Big = Big;
+        
     //AMD.
-    if (typeof define === 'function' && define.amd) {
+    } else if (typeof define === 'function' && define.amd) {
         define(function () {
             return Big;
         });
-
-    // Node and other CommonJS-like environments that support module.exports.
-    } else if (typeof module !== 'undefined' && module.exports) {
-        module.exports = Big;
-        module.exports.Big = Big;
-
+        
     //Browser.
     } else {
         global.Big = Big;


### PR DESCRIPTION
Hi!

This [recent PR](https://github.com/MikeMcl/big.js/pull/85) added a named commonjs export for `Big`.  @googol subsequently amended the DefinitelyTyped definitions to cater for this.

Essentially the goal of his changes was to move usage in a more `es6` direction; namely making this legitimate:

```
import { Big } from 'big.js';
const lookABigJs = new Big(1);
```

That's great, however webpack picks up the first exported branch it can when `Big` is exported.  So it picks up the AMD export **not** the CommonJS export. You can work around this in webpack by deactivating AMD imports but that's somewhat brute force.

Rather than doing that would you consider flipping the export order as I have done in this PR?  So CommonJS is the first branch and AMD is the second.  This will resolve issues for Big users of webpack with TypeScript in a hopefully "futurish" fashion.

If you're interested in the context for this then read a really long post here:

https://github.com/Microsoft/TypeScript/issues/18791

PS As an aside I updated the version number in line with the `package.json`.