### PR TITLE
add module and jsnext:main field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "url": "https://github.com/MikeMcl/big.js.git"
   },
   "main": "big.js",
-  "jsnext:main": "big.mjs",
   "module": "big.mjs",
   "author": {
     "name": "Michael Mclaughlin",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "url": "https://github.com/MikeMcl/big.js.git"
   },
   "main": "big.js",
+  "jsnext:main": "big.mjs",
+  "module": "big.mjs",
   "author": {
     "name": "Michael Mclaughlin",
     "email": "M8ch88l@gmail.com"


### PR DESCRIPTION
i am using the library in an mjs codebase built with rollup and without one of those fields (depending on the rollup-plugin-resolve config, thats why i added both) the config might break. this means without the fields one would need to 
```
import Big from 'big.js/big.mjs'
```
because the mjs module can not be resolved.
