### PR TITLE
add browser field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "url": "https://github.com/MikeMcl/big.js.git"
   },
   "main": "big",
+  "browser": "big.js",
   "module": "big.mjs",
   "author": {
     "name": "Michael Mclaughlin",


### PR DESCRIPTION
Resolves https://github.com/MikeMcl/big.js/issues/95 and https://github.com/MikeMcl/big.js/issues/96

This is a trivial change, but avoids the need for more in depth code change and could be made more verbose to better support es module loading in browser and node, with the addition of browser specific esm files:
```
"module": "big.mjs",
"browser": {
  "./big.js":     "./big.browser.js",
  "./big.mjs": "./big.browser.mjs"
}
```

The goal of this PR is just to get the loading working again for default packager configuration.
For example webpack loads for browser in the following order by default: `["browser", "module", "main"]` and default for node is: `["module", "main"]`.

If anyone wants to use the module version, they should be able to do an override. This would help maintain backwards compatibility while leaving the module field still available.