### PR TITLE
Fixing a typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ const Big = require('big.js');
 ES6 module:
 
 ```javascript
-import Big from 'big.mjs';
+import Big from 'big.js';
 ```
 ## Use
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ const Big = require('big.js');
 ES6 module:
 
 ```javascript
-import Big from 'big.js';
+import Big from './big.mjs';
 ```
 ## Use
 


### PR DESCRIPTION
For "Set up" section in documentation, there was a typo in import example for ES6. 

"import Big from 'big.jms'" 
instead of 
"import Big from 'big.js'"