### PR TITLE
doc(multiply example): fix reference to times function.

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1272,7 +1272,7 @@ z = x.add(y)                      // 2.1000
 
 x = new BigDecimal("1.20")
 y = new BigDecimal("3.45000")
-z = x.multiply(y)                 // 4.1400000
+z = x.times(y)                 // 4.1400000
 </pre>
     <p>
       To specify the precision of a value is to imply that the value lies


### PR DESCRIPTION
Thanks for a great library.

This update the reference to `multiply` in the doc page to `times`. Took me some time to find the correct function because I was searching for `multiply` functionaliy.