### PR TITLE
Fix ESM compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,12 @@
     "bigint",
     "bignum"
   ],
+  "exports": {
+      ".": {
+          "import": "./big.mjs",
+          "require": "./big.js"
+      }
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/MikeMcl/big.js.git"

--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
     "bignum"
   ],
   "exports": {
-      ".": {
-          "import": "./big.mjs",
-          "require": "./big.js"
-      }
+    ".": {
+      "import": "./big.mjs",
+      "require": "./big.js"
+    }
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This allows importing big.js in ESM packages without having to resolve
to the

    import Big from 'big.js/big.mjs';

trick.

Fixes GH-170.