### PR TITLE
Make big.js work when the Object prototype is frozen

### DIFF
--- a/big.js
+++ b/big.js
@@ -111,7 +111,16 @@
 
       // Retain a reference to this Big constructor.
       // Shadow Big.prototype.constructor which points to Object.
-      x.constructor = Big;
+      if (typeof Object.defineProperty === 'function') {
+        // If the Object prototype is frozen, the "constructor" property is non-writable. This means that any objects which inherit this
+        // property cannot have the property changed using an assignment. If using strict mode, attempting that will cause an error. If not
+        // using strict mode, attempting that will be silently ignored.
+        // However, we can still explicitly shadow the prototype's non-writable property by defining a new property on this object.
+        Object.defineProperty(x, 'constructor', { value: Big });
+      } else {
+        // If Object.defineProperty() doesn't exist, attempt to shadow this property using the assignment operator.
+        x.constructor = Big;
+      }
     }
 
     Big.prototype = P;
@@ -960,7 +969,7 @@
    * Big.PE, or a negative exponent equal to or less than Big.NE.
    * Omit the sign for negative zero.
    */
-  P.toJSON = P.toString = function () {
+  function toString() {
     var x = this,
       Big = x.constructor;
     return stringify(x, x.e <= Big.NE || x.e >= Big.PE, !!x.c[0]);
@@ -1011,7 +1020,7 @@
    * Big.PE, or a negative exponent equal to or less than Big.NE.
    * Include the sign for negative zero.
    */
-  P.valueOf = function () {
+  function valueOf() {
     var x = this,
       Big = x.constructor;
     if (Big.strict === true) {
@@ -1019,6 +1028,21 @@
     }
     return stringify(x, x.e <= Big.NE || x.e >= Big.PE, true);
   };
+
+
+  P.toJSON = toString;
+  if (typeof Object.defineProperty === 'function') {
+    // If the Object prototype is frozen, the "toString" and "valueOf" properties are non-writable. This means that any objects which
+    // inherit these property cannot have the property changed using an assignment. If using strict mode, attempting that will cause an
+    // error. If not using strict mode, attempting that will be silently ignored.
+    // However, we can still explicitly shadow the prototype's non-writable properties by defining new properties on this object.
+    Object.defineProperty(P, 'toString', { value: toString });
+    Object.defineProperty(P, 'valueOf', { value: valueOf });
+  } else {
+    // If Object.defineProperty() doesn't exist, attempt to shadow this property using the assignment operator.
+    P.toString = toString;
+    P.valueOf = valueOf;
+  }
 
 
   // Export

--- a/big.mjs
+++ b/big.mjs
@@ -108,16 +108,11 @@ function _Big_() {
 
     // Retain a reference to this Big constructor.
     // Shadow Big.prototype.constructor which points to Object.
-    if (typeof Object.defineProperty === 'function') {
-      // If the Object prototype is frozen, the "constructor" property is non-writable. This means that any objects which inherit this
-      // property cannot have the property changed using an assignment. If using strict mode, attempting that will cause an error. If not
-      // using strict mode, attempting that will be silently ignored.
-      // However, we can still explicitly shadow the prototype's non-writable property by defining a new property on this object.
-      Object.defineProperty(x, 'constructor', { value: Big });
-    } else {
-      // If Object.defineProperty() doesn't exist, attempt to shadow this property using the assignment operator.
-      x.constructor = Big;
-    }
+    // If the Object prototype is frozen, the "constructor" property is non-writable. This means that any objects which inherit this
+    // property cannot have the property changed using an assignment. If using strict mode, attempting that will cause an error. If not
+    // using strict mode, attempting that will be silently ignored.
+    // However, we can still explicitly shadow the prototype's non-writable property by defining a new property on this object.
+    Object.defineProperty(x, 'constructor', { value: Big });
   }
 
   Big.prototype = P;
@@ -966,7 +961,7 @@ P.toFixed = function (dp, rm) {
  * Big.PE, or a negative exponent equal to or less than Big.NE.
  * Omit the sign for negative zero.
  */
-function toString() {
+var toString = P[Symbol.for('nodejs.util.inspect.custom')] = function () {
   var x = this,
     Big = x.constructor;
   return stringify(x, x.e <= Big.NE || x.e >= Big.PE, !!x.c[0]);
@@ -1027,19 +1022,13 @@ function valueOf() {
 };
 
 
-P[Symbol.for('nodejs.util.inspect.custom')] = P.toJSON = toString;
-if (typeof Object.defineProperty === 'function') {
-  // If the Object prototype is frozen, the "toString" and "valueOf" properties are non-writable. This means that any objects which
-  // inherit these property cannot have the property changed using an assignment. If using strict mode, attempting that will cause an
-  // error. If not using strict mode, attempting that will be silently ignored.
-  // However, we can still explicitly shadow the prototype's non-writable properties by defining new properties on this object.
-  Object.defineProperty(P, 'toString', { value: toString });
-  Object.defineProperty(P, 'valueOf', { value: valueOf });
-} else {
-  // If Object.defineProperty() doesn't exist, attempt to shadow this property using the assignment operator.
-  P.toString = toString;
-  P.valueOf = valueOf;
-}
+P.toJSON = toString;
+// If the Object prototype is frozen, the "toString" and "valueOf" properties are non-writable. This means that any objects which
+// inherit these property cannot have the property changed using an assignment. If using strict mode, attempting that will cause an
+// error. If not using strict mode, attempting that will be silently ignored.
+// However, we can still explicitly shadow the prototype's non-writable properties by defining new properties on this object.
+Object.defineProperty(P, 'toString', { value: toString });
+Object.defineProperty(P, 'valueOf', { value: valueOf });
 
 
 // Export

--- a/big.mjs
+++ b/big.mjs
@@ -108,7 +108,16 @@ function _Big_() {
 
     // Retain a reference to this Big constructor.
     // Shadow Big.prototype.constructor which points to Object.
-    x.constructor = Big;
+    if (typeof Object.defineProperty === 'function') {
+      // If the Object prototype is frozen, the "constructor" property is non-writable. This means that any objects which inherit this
+      // property cannot have the property changed using an assignment. If using strict mode, attempting that will cause an error. If not
+      // using strict mode, attempting that will be silently ignored.
+      // However, we can still explicitly shadow the prototype's non-writable property by defining a new property on this object.
+      Object.defineProperty(x, 'constructor', { value: Big });
+    } else {
+      // If Object.defineProperty() doesn't exist, attempt to shadow this property using the assignment operator.
+      x.constructor = Big;
+    }
   }
 
   Big.prototype = P;
@@ -957,7 +966,7 @@ P.toFixed = function (dp, rm) {
  * Big.PE, or a negative exponent equal to or less than Big.NE.
  * Omit the sign for negative zero.
  */
-P[Symbol.for('nodejs.util.inspect.custom')] = P.toJSON = P.toString = function () {
+function toString() {
   var x = this,
     Big = x.constructor;
   return stringify(x, x.e <= Big.NE || x.e >= Big.PE, !!x.c[0]);
@@ -1008,7 +1017,7 @@ P.toPrecision = function (sd, rm) {
  * Big.PE, or a negative exponent equal to or less than Big.NE.
  * Include the sign for negative zero.
  */
-P.valueOf = function () {
+function valueOf() {
   var x = this,
     Big = x.constructor;
   if (Big.strict === true) {
@@ -1016,6 +1025,21 @@ P.valueOf = function () {
   }
   return stringify(x, x.e <= Big.NE || x.e >= Big.PE, true);
 };
+
+
+P[Symbol.for('nodejs.util.inspect.custom')] = P.toJSON = toString;
+if (typeof Object.defineProperty === 'function') {
+  // If the Object prototype is frozen, the "toString" and "valueOf" properties are non-writable. This means that any objects which
+  // inherit these property cannot have the property changed using an assignment. If using strict mode, attempting that will cause an
+  // error. If not using strict mode, attempting that will be silently ignored.
+  // However, we can still explicitly shadow the prototype's non-writable properties by defining new properties on this object.
+  Object.defineProperty(P, 'toString', { value: toString });
+  Object.defineProperty(P, 'valueOf', { value: valueOf });
+} else {
+  // If Object.defineProperty() doesn't exist, attempt to shadow this property using the assignment operator.
+  P.toString = toString;
+  P.valueOf = valueOf;
+}
 
 
 // Export


### PR DESCRIPTION
## Background

_Note: examples use the Node.js REPL with strict mode: `node --use_strict`._

### Inheritance and Shadowing

Objects in JavaScript [inherit properties from their prototype chain](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain). For example, the "toString" property can be accessed on all objects, but it doesn't actually exist on each object, it exists on the global Object prototype:

```js
let obj = {};
obj.toString();
// '[object Object]'
Object.getOwnPropertyDescriptor(obj, 'toString');
// undefined
Object.getOwnPropertyDescriptor(Object.prototype, 'toString');
// { value: [Function: toString], writable: true, enumerable: false, configurable: true }
```

Under normal circumstances, you can assign a property to an object using the `=` operator, and any property of the same name in the object's prototype chain will not be modified, but will be "[shadowed](https://en.wikipedia.org/wiki/Variable_shadowing)" by the new property:

```js
obj.toString = () => 'foo';
obj.toString();
// 'foo'
Object.getOwnPropertyDescriptor(obj, 'toString');
// { value: [Function: toString], writable: true, enumerable: true, configurable: true }
```

### Prototype Pollution

[From Snyk:](https://learn.snyk.io/lessons/prototype-pollution/javascript/)

> Prototype pollution is an injection attack that targets JavaScript runtimes. With prototype pollution, an attacker might control the default values of an object's properties. This allows the attacker to tamper with the logic of the application and can also lead to denial of service or, in extreme cases, remote code execution.

There are a few different ways to mitigate Prototype Pollution, and one way to do it across the board is to [freeze the global "root" objects and their prototypes (Object, Function, Array, etc.)](https://www.npmjs.com/package/nopp)

[From MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze):

> The `Object.freeze()` static method *freezes* an object. Freezing an object [prevents extensions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/preventExtensions) and makes existing properties non-writable and non-configurable. A frozen object can no longer be changed: new properties cannot be added, existing properties cannot be removed, their enumerability, configurability, writability, or value cannot be changed, and the object's prototype cannot be re-assigned.

This means that any attempt to change the Object prototype will fail. If using [strict mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode), it will throw an error; otherwise, it will be silently ignored.

If the Object prototype becomes frozen, all of its properties are no longer writable or configurable:

```js
Object.freeze(Object.prototype);
Object.getOwnPropertyDescriptor(Object.prototype, 'toString');
// { value: [Function: toString], writable: false, enumerable: false, configurable: false }
```

This also prevents shadowing properties with assignment. If an object _doesn't_ already have a property defined (such as "toString"), **and** it inherits a _non-writable_ property of that name from its prototype chain, any attempt to assign the property on that object will fail:

```js
let obj2 = {};
obj2.toString = () => 'bar';
// Uncaught TypeError: Cannot assign to read only property 'toString' of object '#<Object>'
obj2.toString();
// '[object Object]'
```

This behavior is described in the [ECMAScript 2016 specification](https://262.ecma-international.org/7.0/#sec-strict-mode-of-ecmascript):

> Assignment to an undeclared identifier or otherwise unresolvable reference does not create a property in the [global object](https://262.ecma-international.org/7.0/#global-object). When a simple assignment occurs within [strict mode code](https://262.ecma-international.org/7.0/#sec-strict-mode-code), its [LeftHandSideExpression](https://262.ecma-international.org/7.0/#prod-LeftHandSideExpression) must not evaluate to an unresolvable [Reference](https://262.ecma-international.org/7.0/#sec-reference-specification-type). If it does a **ReferenceError** exception is thrown ([6.2.3.2](https://262.ecma-international.org/7.0/#sec-putvalue)). The [LeftHandSideExpression](https://262.ecma-international.org/7.0/#prod-LeftHandSideExpression) also may not be a reference to a data property with the attribute value {[[Writable]]: **false**}, to an accessor property with the attribute value {[[Set]]: **undefined**}, nor to a non-existent property of an object whose [[Extensible]] internal slot has the value **false**. In these cases a `TypeError` exception is thrown ([12.15](https://262.ecma-international.org/7.0/#sec-assignment-operators)).

## The Problem

Unfortunately, this package uses assignment to shadow the "constructor", "toString", and "valueOf" functions:

https://github.com/MikeMcl/big.js/blob/9c6c959c92dc9044a0f98c31f60322fd91243468/big.js#L112-L114

https://github.com/MikeMcl/big.js/blob/9c6c959c92dc9044a0f98c31f60322fd91243468/big.js#L963

https://github.com/MikeMcl/big.js/blob/9c6c959c92dc9044a0f98c31f60322fd91243468/big.js#L1014

This means that projects cannot use this package if they have frozen the global Object prototype.

## The Solution

You can still shadow non-writable prototype properties by explicitly defining a new data property on the object:

```js
Object.defineProperty(obj2, 'toString', { value: () => 'bar' });
obj2.toString();
// 'bar'
Object.getOwnPropertyDescriptor(obj2, 'toString');
// { value: [Function: toString], writable: false, enumerable: false, configurable: false }
```

The module can be changed to use this method of shadowing so it is compatible with this approach of mitigating Prototype Pollution 🎉